### PR TITLE
v0.7.1

### DIFF
--- a/src/main/java/com/teammatching/demo/config/OpenApiConfig.java
+++ b/src/main/java/com/teammatching/demo/config/OpenApiConfig.java
@@ -47,7 +47,7 @@ public class OpenApiConfig {
     public OpenAPI openAPI() {
         Info info = new Info()
                 .title("Team Mon")
-                .version("0.6")
+                .version("0.7.1")
                 .description("Team Mon 서비스의 API Docs 입니다.");
         return new OpenAPI()
                 .components(new Components())

--- a/src/main/java/com/teammatching/demo/domain/dto/AdmissionDto.java
+++ b/src/main/java/com/teammatching/demo/domain/dto/AdmissionDto.java
@@ -48,15 +48,15 @@ public record AdmissionDto(
             Long id,
             UserAccountDto userAccountDto
     ) {
-        public static SimpleResponse from(AdmissionDto dto) {
+        public static SimpleResponse from(Admission entity) {
             return SimpleResponse.builder()
-                    .id(dto.id)
-                    .userAccountDto(dto.userAccountDto)
+                    .id(entity.getId())
+                    .userAccountDto(UserAccountDto.from(entity.getUserAccount()))
                     .build();
         }
     }
 
-    @Schema(name = "AdmissionDto.CreateResponse(가입 신청 생성 요청 Dto)")
+    @Schema(name = "AdmissionDto.CreateRequest(가입 신청 생성 요청 Dto)")
     public record CreateRequest(
             String application
     ) {

--- a/src/main/java/com/teammatching/demo/domain/dto/CommentDto.java
+++ b/src/main/java/com/teammatching/demo/domain/dto/CommentDto.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 public record CommentDto(
         Long id,
         String content,
-        PostDto postDto,
+        Long postId,
         UserAccountDto userAccountDto,
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
@@ -28,7 +28,7 @@ public record CommentDto(
         return CommentDto.builder()
                 .id(entity.getId())
                 .content(entity.getContent())
-                .postDto(PostDto.from(entity.getPost()))
+                .postId(entity.getPost().getId())
                 .userAccountDto(UserAccountDto.from(entity.getUserAccount()))
                 .createdAt(entity.getCreatedAt())
                 .createdBy(entity.getCreatedBy())
@@ -69,7 +69,7 @@ public record CommentDto(
         }
     }
 
-    @Schema(name = "CommentDto.SimpleResponse(댓글 간단 응답 Dto)")
+    @Schema(name = "CommentDto.SimpleResponse(간단 댓글 응답 Dto)")
     @Builder
     public record SimpleResponse(
             Long id,
@@ -79,12 +79,11 @@ public record CommentDto(
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
             LocalDateTime createdAt
     ) {
-        public static SimpleResponse from(CommentDto dto) {
+        public static SimpleResponse from(Comment entity) {
             return SimpleResponse.builder()
-                    .id(dto.id)
-                    .content(dto.content)
-                    .postSimpleDto(PostDto.SimpleResponse.from(dto.postDto))
-                    .createdAt(dto.createdAt)
+                    .id(entity.getId())
+                    .content(entity.getContent())
+                    .postSimpleDto(PostDto.SimpleResponse.from(entity.getPost()))
                     .build();
         }
     }

--- a/src/main/java/com/teammatching/demo/domain/dto/PostDto.java
+++ b/src/main/java/com/teammatching/demo/domain/dto/PostDto.java
@@ -60,46 +60,16 @@ public record PostDto(
             Long id,
             String title,
             String hashtag,
-            String userId,
-            String nickname,
+            UserAccountDto userAccountDto,
             Integer commentsCount,
             LocalDateTime createdAt
     ) {
-        public static SimpleResponse from(PostDto dto) {
+        public static SimpleResponse from(Post entity) {
             return SimpleResponse.builder()
-                    .id(dto.id)
-                    .title(dto.title)
-                    .hashtag(dto.hashtag)
-                    .userId(dto.userAccountDto().userId())
-                    .nickname(dto.userAccountDto.nickname())
-                    .commentsCount(dto.commentDtos.size())
-                    .createdAt(dto.createdAt)
-                    .build();
-        }
-    }
-
-    @Schema(name = "PostDto.DetailResponse(게시물 상세 응답 Dto)")
-    @Builder
-    public record DetailResponse(
-            Long id,
-            String title,
-            String content,
-            String hashtag,
-            UserAccountDto userAccountDto,
-            Set<CommentDto> commentDtos,
-            String nickname,
-
-            LocalDateTime createdAt
-    ) {
-        public static DetailResponse from(PostDto dto) {
-            return DetailResponse.builder()
-                    .id(dto.id)
-                    .title(dto.title)
-                    .content(dto.content)
-                    .hashtag(dto.hashtag)
-                    .userAccountDto(dto.userAccountDto)
-                    .commentDtos(dto.commentDtos)
-                    .createdAt(dto.createdAt)
+                    .id(entity.getId())
+                    .title(entity.getTitle())
+                    .hashtag(entity.getHashtag())
+                    .userAccountDto(UserAccountDto.from(entity.getUserAccount()))
                     .build();
         }
     }

--- a/src/main/java/com/teammatching/demo/domain/dto/TeamDto.java
+++ b/src/main/java/com/teammatching/demo/domain/dto/TeamDto.java
@@ -78,17 +78,17 @@ public record TeamDto(
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
             LocalDateTime createdAt
     ) {
-        public static SimpleResponse from(TeamDto dto) {
+        public static SimpleResponse from(Team entity) {
             return SimpleResponse.builder()
-                    .id(dto.id)
-                    .adminUserAccountDto(dto.adminUserAccountDto)
-                    .name(dto.name)
-                    .category(dto.category)
-                    .hashtag(dto.hashtag)
-                    .capacity(dto.capacity)
-                    .total(dto.total)
-                    .deadline(dto.deadline)
-                    .createdAt(dto.createdAt)
+                    .id(entity.getId())
+                    .adminUserAccountDto(UserAccountDto.from(entity.getAdminUserAccount()))
+                    .name(entity.getName())
+                    .capacity(entity.getCapacity())
+                    .hashtag(entity.getHashtag())
+                    .capacity(entity.getCapacity())
+                    .total(entity.getTotal())
+                    .deadline(entity.getDeadline())
+                    .createdAt(entity.getCreatedAt())
                     .build();
         }
 

--- a/src/main/java/com/teammatching/demo/web/controller/AdmissionController.java
+++ b/src/main/java/com/teammatching/demo/web/controller/AdmissionController.java
@@ -41,8 +41,7 @@ public class AdmissionController {
         return ResponseResult.<Page<AdmissionDto.SimpleResponse>>builder()
                 .resultCode(HttpStatus.OK.value())
                 .resultMessage(ResponseMessage.SUCCESS_GET_SIMPLE_ADMISSION)
-                .resultData(admissionService.getSimpleAdmission(teamId, principal.userId(), pageable)
-                        .map(AdmissionDto.SimpleResponse::from))
+                .resultData(admissionService.getSimpleAdmission(teamId, principal.userId(), pageable))
                 .build();
     }
 

--- a/src/main/java/com/teammatching/demo/web/controller/MyPageController.java
+++ b/src/main/java/com/teammatching/demo/web/controller/MyPageController.java
@@ -93,8 +93,7 @@ public class MyPageController {
         return ResponseResult.<Page<PostDto.SimpleResponse>>builder()
                 .resultCode(HttpStatus.OK.value())
                 .resultMessage(ResponseMessage.SUCCESS_GET_MY_POSTS)
-                .resultData(myPageService.getMyPosts(userId, principal.userId(), pageable)
-                        .map(PostDto.SimpleResponse::from))
+                .resultData(myPageService.getMyPosts(userId, principal.userId(), pageable))
                 .build();
     }
 
@@ -112,8 +111,7 @@ public class MyPageController {
         return ResponseResult.<Page<CommentDto.SimpleResponse>>builder()
                 .resultCode(HttpStatus.OK.value())
                 .resultMessage(ResponseMessage.SUCCESS_GET_MY_COMMENTS)
-                .resultData(myPageService.getMyComments(userId, principal.userId(), pageable)
-                        .map(CommentDto.SimpleResponse::from))
+                .resultData(myPageService.getMyComments(userId, principal.userId(), pageable))
                 .build();
     }
 
@@ -131,8 +129,7 @@ public class MyPageController {
         return ResponseResult.<Page<TeamDto.SimpleResponse>>builder()
                 .resultCode(HttpStatus.OK.value())
                 .resultMessage(ResponseMessage.SUCCESS_GET_MY_TEAMS)
-                .resultData(myPageService.getMyTeams(userId, principal.userId(), pageable)
-                        .map(TeamDto.SimpleResponse::from))
+                .resultData(myPageService.getMyTeams(userId, principal.userId(), pageable))
                 .build();
     }
 
@@ -150,8 +147,7 @@ public class MyPageController {
         return ResponseResult.<Page<TeamDto.SimpleResponse>>builder()
                 .resultCode(HttpStatus.OK.value())
                 .resultMessage(ResponseMessage.SUCCESS_GET_MY_TEAMS)
-                .resultData(myPageService.getMyJudgingTeams(userId, principal.userId(), pageable)
-                        .map(TeamDto.SimpleResponse::from))
+                .resultData(myPageService.getMyJudgingTeams(userId, principal.userId(), pageable))
                 .build();
     }
 }

--- a/src/main/java/com/teammatching/demo/web/controller/PostController.java
+++ b/src/main/java/com/teammatching/demo/web/controller/PostController.java
@@ -37,23 +37,23 @@ public class PostController {
         return ResponseResult.<Page<PostDto.SimpleResponse>>builder()
                 .resultCode(HttpStatus.OK.value())
                 .resultMessage(ResponseMessage.SUCCESS_GET_SIMPLE_POSTS)
-                .resultData(postService.getSimplePosts(pageable).map(PostDto.SimpleResponse::from))
+                .resultData(postService.getSimplePosts(pageable))
                 .build();
     }
 
     @Operation(
-            summary = "단일 게시글 상세 조회(댓글도 함께)",
+            summary = "단일 게시글 상세 조회",
             description = "단일 게시글에 대한 상세 정보를 댓글과 함께 제공합니다."
     )
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{postId}")
-    public ResponseResult<PostDto.DetailResponse> getPostById(
+    public ResponseResult<PostDto> getPostById(
             @PathVariable("postId") Long postId
     ) {
-        return ResponseResult.<PostDto.DetailResponse>builder()
+        return ResponseResult.<PostDto>builder()
                 .resultCode(HttpStatus.OK.value())
                 .resultMessage(ResponseMessage.SUCCESS_GET_POST_BY_ID)
-                .resultData(PostDto.DetailResponse.from(postService.getPostById(postId)))
+                .resultData(postService.getPostById(postId))
                 .build();
     }
 

--- a/src/main/java/com/teammatching/demo/web/controller/TeamController.java
+++ b/src/main/java/com/teammatching/demo/web/controller/TeamController.java
@@ -38,7 +38,7 @@ public class TeamController {
         return ResponseResult.<Page<TeamDto.SimpleResponse>>builder()
                 .resultCode(HttpStatus.OK.value())
                 .resultMessage(ResponseMessage.SUCCESS_GET_SIMPLE_TEAMS)
-                .resultData(teamService.getSimpleTeams(pageable).map(TeamDto.SimpleResponse::from))
+                .resultData(teamService.getSimpleTeams(pageable))
                 .build();
     }
 

--- a/src/main/java/com/teammatching/demo/web/service/AdmissionService.java
+++ b/src/main/java/com/teammatching/demo/web/service/AdmissionService.java
@@ -39,11 +39,11 @@ public class AdmissionService {
     }
 
     @Transactional(readOnly = true)
-    public Page<AdmissionDto> getSimpleAdmission(Long teamId, String adminId, Pageable pageable) {
+    public Page<AdmissionDto.SimpleResponse> getSimpleAdmission(Long teamId, String adminId, Pageable pageable) {
         Team team = teamRepository.getReferenceById(teamId);
         if (team.getAdminUserAccount().getUserId().equals(adminId)) {
             return admissionRepository.findByTeam_Id(teamId, pageable)
-                    .map(AdmissionDto::from);
+                    .map(AdmissionDto.SimpleResponse::from);
         } else {
             throw new NotEqualsException.TeamAdmin();
         }

--- a/src/main/java/com/teammatching/demo/web/service/MyPageService.java
+++ b/src/main/java/com/teammatching/demo/web/service/MyPageService.java
@@ -42,38 +42,38 @@ public class MyPageService {
     }
 
     @Transactional(readOnly = true)
-    public Page<PostDto> getMyPosts(String userId, String authenticatedUserId, Pageable pageable) {
+    public Page<PostDto.SimpleResponse> getMyPosts(String userId, String authenticatedUserId, Pageable pageable) {
         if (userId.equals(authenticatedUserId)) {
-            return postRepository.findByUserAccount_UserId(userId, pageable).map(PostDto::from);
+            return postRepository.findByUserAccount_UserId(userId, pageable).map(PostDto.SimpleResponse::from);
         } else {
             throw new NotEqualsException.UserAccount();
         }
     }
 
     @Transactional(readOnly = true)
-    public Page<CommentDto> getMyComments(String userId, String authenticatedUserId, Pageable pageable) {
+    public Page<CommentDto.SimpleResponse> getMyComments(String userId, String authenticatedUserId, Pageable pageable) {
         if (userId.equals(authenticatedUserId)) {
-            return commentRepository.findByUserAccount_UserId(userId, pageable).map(CommentDto::from);
+            return commentRepository.findByUserAccount_UserId(userId, pageable).map(CommentDto.SimpleResponse::from);
         } else {
             throw new NotEqualsException.UserAccount();
         }
     }
 
     @Transactional(readOnly = true)
-    public Page<TeamDto> getMyTeams(String userId, String authenticatedUserId, Pageable pageable) {
+    public Page<TeamDto.SimpleResponse> getMyTeams(String userId, String authenticatedUserId, Pageable pageable) {
         if (userId.equals(authenticatedUserId)) {
             return admissionRepository.findAllByUserAccount_UserIdAndApprovalIsTrue(userId, pageable)
-                    .map(admission -> TeamDto.from(admission.getTeam()));
+                    .map(admission -> TeamDto.SimpleResponse.from(admission.getTeam()));
         } else {
             throw new NotEqualsException.UserAccount();
         }
     }
 
     @Transactional(readOnly = true)
-    public Page<TeamDto> getMyJudgingTeams(String userId, String authenticatedUserId, Pageable pageable) {
+    public Page<TeamDto.SimpleResponse> getMyJudgingTeams(String userId, String authenticatedUserId, Pageable pageable) {
         if (userId.equals(authenticatedUserId)) {
             return admissionRepository.findAllByUserAccount_UserIdAndApprovalIsFalse(userId, pageable)
-                    .map(admission -> TeamDto.from(admission.getTeam()));
+                    .map(admission -> TeamDto.SimpleResponse.from(admission.getTeam()));
         } else {
             throw new NotEqualsException.UserAccount();
         }
@@ -83,6 +83,4 @@ public class MyPageService {
         return userAccountRepository.findById(userId)
                 .orElseThrow(NotFoundException.UserAccount::new);
     }
-
-
 }

--- a/src/main/java/com/teammatching/demo/web/service/PostService.java
+++ b/src/main/java/com/teammatching/demo/web/service/PostService.java
@@ -32,8 +32,8 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public Page<PostDto> getSimplePosts(Pageable pageable) {
-        return postRepository.findAll(pageable).map(PostDto::from);
+    public Page<PostDto.SimpleResponse> getSimplePosts(Pageable pageable) {
+        return postRepository.findAll(pageable).map(PostDto.SimpleResponse::from);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/teammatching/demo/web/service/TeamService.java
+++ b/src/main/java/com/teammatching/demo/web/service/TeamService.java
@@ -34,9 +34,8 @@ public class TeamService {
     }
 
     @Transactional(readOnly = true)
-    public Page<TeamDto> getSimpleTeams(Pageable pageable) {
-
-        return teamRepository.findAll(pageable).map(TeamDto::from);
+    public Page<TeamDto.SimpleResponse> getSimpleTeams(Pageable pageable) {
+        return teamRepository.findAll(pageable).map(TeamDto.SimpleResponse::from);
     }
 
     public void createTeam(TeamDto request, String userId) {


### PR DESCRIPTION
- 이제 모든 DTO의 from 메소드가 파라미터로 해당 도메인의 entity를 받음 (더이상 상위 DTO를 거치지 않음)
- PostDto : DetailResponse DTO를 제거함
- CommentDto : 순환참조를 방지하기 위해 postDto -> postId로 필드 변경
- 모든 서비스는 하나의 API에 종속됨
